### PR TITLE
Sync rss status with firestore

### DIFF
--- a/COPY_THIS_COMMAND.txt
+++ b/COPY_THIS_COMMAND.txt
@@ -1,0 +1,35 @@
+CURL COMMAND TO SYNC RSS STATUS
+================================
+
+Copy this entire line:
+
+curl -X POST https://copernicus-podcast-api-204731194849.us-central1.run.app/api/admin/episodes/sync-rss-status
+
+================================
+HOW TO USE:
+================================
+
+Option 1: Copy from this file
+- Open this file: COPY_THIS_COMMAND.txt
+- Select the line starting with "curl -X POST"
+- Copy it (Ctrl+C or Cmd+C)
+- Paste into your terminal
+
+Option 2: Type it manually
+- Type: curl -X POST
+- Press space
+- Type: https://copernicus-podcast-api-204731194849.us-central1.run.app/api/admin/episodes/sync-rss-status
+- Press Enter
+
+Option 3: Use the shell script
+- Run: bash run_sync.sh
+- Or: chmod +x run_sync.sh && ./run_sync.sh
+
+================================
+WHAT IT DOES:
+================================
+This command triggers the RSS sync endpoint on your Cloud Run service.
+It will update Firestore to mark all episodes in your RSS feed as 
+submitted_to_rss: true.
+
+You should see JSON output with statistics about what was updated.

--- a/SYNC_RSS_STATUS_GUIDE.md
+++ b/SYNC_RSS_STATUS_GUIDE.md
@@ -1,0 +1,320 @@
+# How to Run sync_rss_status.py
+
+This guide provides step-by-step instructions for running the RSS sync script to update Firestore with episodes from your RSS feed.
+
+## Prerequisites
+
+1. **Google Cloud SDK (gcloud)** installed
+2. **Python 3.8+** installed
+3. **Access to your GCP project** with Firestore and GCS permissions
+
+## Step-by-Step Instructions
+
+### Option 1: Run on Your Local Machine
+
+#### Step 1: Install Google Cloud SDK (if not already installed)
+
+```bash
+# On macOS
+brew install google-cloud-sdk
+
+# On Linux
+curl https://sdk.cloud.google.com | bash
+exec -l $SHELL
+
+# On Windows
+# Download from: https://cloud.google.com/sdk/docs/install
+```
+
+#### Step 2: Authenticate with Google Cloud
+
+```bash
+# Login to your Google account
+gcloud auth login
+
+# Set your default project
+gcloud config set project regal-scholar-453620-r7
+
+# Set up Application Default Credentials (required for the script)
+gcloud auth application-default login
+```
+
+This will open a browser window for authentication. After completing, your credentials will be stored locally.
+
+#### Step 3: Install Python Dependencies
+
+```bash
+cd /workspace  # or wherever your project is located
+
+# Install required packages
+pip3 install google-cloud-firestore google-cloud-storage
+
+# Or if using a virtual environment (recommended):
+python3 -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install google-cloud-firestore google-cloud-storage
+```
+
+#### Step 4: Set Environment Variables (Optional)
+
+The script has defaults, but you can override them:
+
+```bash
+export GOOGLE_CLOUD_PROJECT="regal-scholar-453620-r7"
+export GCP_AUDIO_BUCKET="regal-scholar-453620-r7-podcast-storage"
+```
+
+#### Step 5: Test with Dry Run
+
+```bash
+cd /workspace
+python3 sync_rss_status.py --dry-run
+```
+
+This will show you what changes would be made without actually updating Firestore.
+
+#### Step 6: Run the Actual Sync
+
+```bash
+python3 sync_rss_status.py
+```
+
+You should see output like:
+```
+======================================================================
+🔄 RSS Feed to Firestore Sync Script
+======================================================================
+Project: regal-scholar-453620-r7
+Database: copernicusai
+RSS Feed: https://storage.googleapis.com/...
+======================================================================
+
+📡 Fetching RSS feed from: https://storage.googleapis.com/...
+✅ Successfully fetched RSS feed (123456 bytes)
+🔍 Parsing RSS feed to extract episode GUIDs...
+📋 Found 39 items in RSS feed
+  ✓ Found GUID: news-bio-28032025
+  ...
+✅ Extracted 39 unique GUIDs from RSS feed
+
+🔄 Syncing Firestore with RSS feed...
+🔌 Connecting to Firestore (project: regal-scholar-453620-r7, database: copernicusai)...
+✅ Firestore client initialized
+📚 Fetching all podcast_jobs from Firestore...
+📊 Found 50 total podcast jobs in Firestore
+
+📝 Updating documents that appear in RSS feed (39 episodes)...
+  ✅ news-bio-28032025: Updated submitted_to_rss=true
+  ✅ news-chem-28032025: Updated submitted_to_rss=true
+  ...
+
+📊 SYNC SUMMARY
+======================================================================
+Total episodes in RSS feed: 39
+Total podcast jobs in Firestore: 50
+Episodes updated to submitted_to_rss=true: 37
+Episodes already marked as submitted_to_rss=true: 2
+Episodes in Firestore but NOT in RSS (marked true): 0
+======================================================================
+
+✅ Sync completed successfully!
+```
+
+---
+
+### Option 2: Run on Google Cloud Shell
+
+Google Cloud Shell already has gcloud and Python pre-installed.
+
+#### Step 1: Open Cloud Shell
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com)
+2. Click the Cloud Shell icon (top right)
+3. Wait for the shell to initialize
+
+#### Step 2: Clone or Upload Your Project
+
+```bash
+# If your code is in a git repo:
+git clone <your-repo-url>
+cd <your-project-directory>
+
+# Or upload sync_rss_status.py via the Cloud Shell editor
+```
+
+#### Step 3: Install Dependencies
+
+```bash
+pip3 install --user google-cloud-firestore google-cloud-storage
+```
+
+#### Step 4: Authenticate (usually automatic in Cloud Shell)
+
+```bash
+# Verify authentication
+gcloud auth list
+
+# If needed, set project
+gcloud config set project regal-scholar-453620-r7
+```
+
+#### Step 5: Run the Script
+
+```bash
+# Dry run first
+python3 sync_rss_status.py --dry-run
+
+# Then actual sync
+python3 sync_rss_status.py
+```
+
+---
+
+### Option 3: Run via Cloud Run API Endpoint
+
+If you've deployed the updated `main.py` with the endpoint, you can trigger the sync via HTTP:
+
+#### Step 1: Get Your Cloud Run URL
+
+Your Cloud Run service URL should be something like:
+```
+https://copernicus-podcast-api-204731194849.us-central1.run.app
+```
+
+#### Step 2: Call the Endpoint
+
+```bash
+# Using curl
+curl -X POST https://copernicus-podcast-api-204731194849.us-central1.run.app/api/admin/episodes/sync-rss-status
+
+# Or using a tool like Postman or httpie
+http POST https://copernicus-podcast-api-204731194849.us-central1.run.app/api/admin/episodes/sync-rss-status
+```
+
+The endpoint will return JSON with statistics:
+```json
+{
+  "status": "success",
+  "message": "RSS status synced successfully",
+  "stats": {
+    "total_in_rss": 39,
+    "total_in_firestore": 50,
+    "updated": 37,
+    "already_marked": 2,
+    "not_in_rss_but_marked_true": 0,
+    "missing_in_firestore": []
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+### Error: "No module named 'google'"
+
+**Solution:** Install the required packages:
+```bash
+pip3 install google-cloud-firestore google-cloud-storage
+```
+
+### Error: "Could not automatically determine credentials"
+
+**Solution:** Set up Application Default Credentials:
+```bash
+gcloud auth application-default login
+```
+
+### Error: "Permission denied" or "403 Forbidden"
+
+**Solution:** Ensure your account has the necessary IAM roles:
+- `roles/datastore.user` (for Firestore)
+- `roles/storage.objectViewer` (for reading GCS)
+
+You can check your roles:
+```bash
+gcloud projects get-iam-policy regal-scholar-453620-r7 --flatten="bindings[].members" --filter="bindings.members:user:YOUR_EMAIL"
+```
+
+### Error: "Database not found" or "Database copernicusai not found"
+
+**Solution:** Verify the database name. You can list databases:
+```bash
+gcloud firestore databases list --project=regal-scholar-453620-r7
+```
+
+If your database has a different name, set it:
+```bash
+export FIRESTORE_DATABASE="your-database-name"
+```
+
+Or modify the script's `FIRESTORE_DATABASE` constant.
+
+### Script Hangs or Times Out
+
+**Possible causes:**
+1. **Network issues** - Check your internet connection
+2. **Firestore connection** - Verify you can access Firestore from your location
+3. **Large dataset** - If you have thousands of documents, the script may take longer
+
+**Solution:** Add timeout handling or run in smaller batches. You can also check Firestore quotas:
+```bash
+gcloud firestore operations list --project=regal-scholar-453620-r7
+```
+
+### RSS Feed Not Found
+
+**Solution:** Verify the RSS feed URL is accessible:
+```bash
+curl https://storage.googleapis.com/regal-scholar-453620-r7-podcast-storage/feeds/copernicus-mvp-rss-feed.xml
+```
+
+If it's not public, the script will try to read it directly from GCS (requires authentication).
+
+---
+
+## What the Script Does
+
+1. **Fetches RSS Feed**: Downloads the RSS XML from GCS (either via public URL or direct GCS access)
+2. **Extracts GUIDs**: Parses all `<guid>` elements from RSS `<item>` entries
+3. **Queries Firestore**: Gets all documents from the `podcast_jobs` collection
+4. **Matches & Updates**: For each Firestore document:
+   - If the document ID matches an RSS GUID → sets `submitted_to_rss: true`
+   - If already `true` → skips (logs it)
+   - If marked `true` but not in RSS → logs a warning
+5. **Reports Statistics**: Shows summary of what was updated
+
+---
+
+## Expected Results
+
+After running successfully, you should see:
+- **39 episodes** marked as `submitted_to_rss: true` in Firestore (matching your RSS feed)
+- Statistics showing how many were updated vs. already marked
+- Any episodes in RSS that don't exist in Firestore (logged as warnings)
+
+You can verify in the Firestore console:
+1. Go to [Firestore Console](https://console.cloud.google.com/firestore)
+2. Select your project and database
+3. Navigate to `podcast_jobs` collection
+4. Filter or check documents - you should see `submitted_to_rss: true` for episodes in the RSS feed
+
+---
+
+## Next Steps
+
+After syncing:
+1. **Verify in Firestore Console** - Check that episodes show `submitted_to_rss: true`
+2. **Check Your Frontend** - The `podcast-database-table.html` should now show more episodes as "Published to RSS"
+3. **Set Up Automation** (Optional) - Consider running this script periodically via Cloud Scheduler or as a Cloud Function
+
+---
+
+## Need Help?
+
+If you encounter issues:
+1. Check the error message carefully
+2. Verify your GCP authentication: `gcloud auth list`
+3. Test Firestore access: Try querying Firestore via the console
+4. Test RSS feed access: Try accessing the RSS URL in a browser
+5. Run with `--dry-run` first to see what would happen without making changes

--- a/check_setup.py
+++ b/check_setup.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Diagnostic script to check if your environment is ready to run sync_rss_status.py
+"""
+
+import os
+import sys
+
+print("=" * 70)
+print("🔍 Environment Diagnostic Check")
+print("=" * 70)
+print()
+
+# Check Python version
+print("1. Python Version:")
+print(f"   ✓ Python {sys.version}")
+print(f"   ✓ Executable: {sys.executable}")
+print()
+
+# Check if we're in the right directory
+print("2. Current Directory:")
+current_dir = os.getcwd()
+print(f"   Current: {current_dir}")
+script_path = os.path.join(current_dir, "sync_rss_status.py")
+if os.path.exists(script_path):
+    print(f"   ✓ sync_rss_status.py found at: {script_path}")
+else:
+    print(f"   ❌ sync_rss_status.py NOT found!")
+    print(f"   Expected at: {script_path}")
+print()
+
+# Check for required Python packages
+print("3. Required Python Packages:")
+required_packages = [
+    ("google.cloud.firestore", "google-cloud-firestore"),
+    ("google.cloud.storage", "google-cloud-storage"),
+]
+
+all_installed = True
+for module_name, package_name in required_packages:
+    try:
+        __import__(module_name)
+        print(f"   ✓ {package_name} installed")
+    except ImportError:
+        print(f"   ❌ {package_name} NOT installed")
+        print(f"      Install with: pip3 install {package_name}")
+        all_installed = False
+print()
+
+# Check for gcloud CLI
+print("4. Google Cloud SDK (gcloud):")
+gcloud_paths = [
+    "/usr/bin/gcloud",
+    "/usr/local/bin/gcloud",
+    os.path.expanduser("~/google-cloud-sdk/bin/gcloud"),
+]
+gcloud_found = False
+for path in gcloud_paths:
+    if os.path.exists(path):
+        print(f"   ✓ Found at: {path}")
+        gcloud_found = True
+        break
+
+# Also check PATH
+import shutil
+gcloud_in_path = shutil.which("gcloud")
+if gcloud_in_path:
+    print(f"   ✓ Found in PATH: {gcloud_in_path}")
+    gcloud_found = True
+
+if not gcloud_found:
+    print("   ⚠️  gcloud not found")
+    print("   This is OK if you're using a service account key file")
+    print("   Or if you'll authenticate via: gcloud auth application-default login")
+print()
+
+# Check environment variables
+print("5. Environment Variables:")
+project_id = os.getenv("GOOGLE_CLOUD_PROJECT", "NOT SET (will use default: regal-scholar-453620-r7)")
+bucket = os.getenv("GCP_AUDIO_BUCKET", "NOT SET (will use default: regal-scholar-453620-r7-podcast-storage)")
+print(f"   GOOGLE_CLOUD_PROJECT: {project_id}")
+print(f"   GCP_AUDIO_BUCKET: {bucket}")
+print()
+
+# Check for GCP credentials
+print("6. GCP Authentication:")
+credential_paths = [
+    os.path.expanduser("~/.config/gcloud/application_default_credentials.json"),
+    os.path.expanduser("~/.config/gcloud/legacy_credentials"),
+    os.getenv("GOOGLE_APPLICATION_CREDENTIALS", ""),
+]
+
+has_creds = False
+for cred_path in credential_paths:
+    if cred_path and os.path.exists(cred_path):
+        print(f"   ✓ Found credentials at: {cred_path}")
+        has_creds = True
+        break
+
+if not has_creds:
+    print("   ⚠️  No application default credentials found")
+    print("   You may need to run: gcloud auth application-default login")
+    print("   Or set GOOGLE_APPLICATION_CREDENTIALS to a service account key file")
+print()
+
+# Summary
+print("=" * 70)
+print("📊 Summary:")
+print("=" * 70)
+
+issues = []
+if not os.path.exists(script_path):
+    issues.append("❌ sync_rss_status.py not found in current directory")
+if not all_installed:
+    issues.append("❌ Required Python packages not installed")
+if not has_creds:
+    issues.append("⚠️  GCP credentials not found (may need authentication)")
+
+if not issues:
+    print("✅ All checks passed! You should be able to run sync_rss_status.py")
+    print()
+    print("Next steps:")
+    print("  1. Run: python3 sync_rss_status.py --dry-run")
+    print("  2. If that works, run: python3 sync_rss_status.py")
+else:
+    print("Issues found:")
+    for issue in issues:
+        print(f"  {issue}")
+    print()
+    print("Fix the issues above, then try again.")
+
+print("=" * 70)

--- a/cloud-run-backend/main.py
+++ b/cloud-run-backend/main.py
@@ -2967,6 +2967,92 @@ async def submit_podcast_to_rss(submission: PodcastSubmission):
         print(f"❌ Error submitting podcast to RSS: {e}")
         raise HTTPException(status_code=500, detail="Failed to submit podcast to RSS")
 
+@app.post("/api/admin/episodes/sync-rss-status")
+async def sync_rss_status():
+    """Sync Firestore episode catalog with RSS feed status"""
+    if not db:
+        raise HTTPException(status_code=503, detail="Firestore service is unavailable")
+    
+    try:
+        import xml.etree.ElementTree as ET
+        import requests
+        
+        # Configuration
+        GCS_BUCKET = os.getenv("GCP_AUDIO_BUCKET", "regal-scholar-453620-r7-podcast-storage")
+        RSS_FEED_PATH = "feeds/copernicus-mvp-rss-feed.xml"
+        RSS_FEED_URL = f"https://storage.googleapis.com/{GCS_BUCKET}/{RSS_FEED_PATH}"
+        
+        # Fetch RSS feed
+        print(f"📡 Fetching RSS feed from: {RSS_FEED_URL}")
+        response = requests.get(RSS_FEED_URL, timeout=30)
+        response.raise_for_status()
+        rss_content = response.text
+        
+        # Parse RSS to extract GUIDs
+        root = ET.fromstring(rss_content)
+        items = root.findall(".//item")
+        rss_guids = set()
+        for item in items:
+            guid_elem = item.find("guid")
+            if guid_elem is not None and guid_elem.text:
+                rss_guids.add(guid_elem.text.strip())
+        
+        print(f"✅ Found {len(rss_guids)} episodes in RSS feed")
+        
+        # Get all podcast_jobs
+        all_podcasts = list(db.collection('podcast_jobs').stream())
+        print(f"📊 Found {len(all_podcasts)} total podcast jobs in Firestore")
+        
+        stats = {
+            'total_in_rss': len(rss_guids),
+            'total_in_firestore': len(all_podcasts),
+            'updated': 0,
+            'already_marked': 0,
+            'not_in_rss_but_marked_true': 0,
+            'missing_in_firestore': []
+        }
+        
+        # Update documents that are in RSS feed
+        for podcast_doc in all_podcasts:
+            doc_id = podcast_doc.id
+            doc_data = podcast_doc.to_dict()
+            current_status = doc_data.get('submitted_to_rss', False)
+            
+            if doc_id in rss_guids:
+                if current_status is True:
+                    stats['already_marked'] += 1
+                else:
+                    stats['updated'] += 1
+                    podcast_doc.reference.update({
+                        'submitted_to_rss': True,
+                        'rss_synced_at': datetime.utcnow().isoformat()
+                    })
+                    print(f"✅ Updated {doc_id}: submitted_to_rss=true")
+            else:
+                if current_status is True:
+                    stats['not_in_rss_but_marked_true'] += 1
+        
+        # Check for RSS GUIDs not in Firestore
+        firestore_doc_ids = {doc.id for doc in all_podcasts}
+        missing = rss_guids - firestore_doc_ids
+        if missing:
+            stats['missing_in_firestore'] = sorted(list(missing))
+            print(f"⚠️  {len(missing)} RSS GUIDs not found in Firestore")
+        
+        print(f"✅ Sync completed: {stats['updated']} updated, {stats['already_marked']} already marked")
+        
+        return {
+            "status": "success",
+            "message": "RSS status synced successfully",
+            "stats": stats
+        }
+        
+    except Exception as e:
+        print(f"❌ Error syncing RSS status: {e}")
+        import traceback
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=f"Failed to sync RSS status: {str(e)}")
+
 # Modify existing generate-podcast endpoint to support subscribers
 @app.post("/generate-podcast-with-subscriber")
 async def generate_podcast_with_subscriber(request: PodcastRequest, subscriber_id: Optional[str] = None):

--- a/run_sync.sh
+++ b/run_sync.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run RSS sync via API endpoint
+
+curl -X POST https://copernicus-podcast-api-204731194849.us-central1.run.app/api/admin/episodes/sync-rss-status

--- a/sync_rss_status.py
+++ b/sync_rss_status.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Sync Firestore episode catalog with RSS feed status.
+
+This script:
+1. Reads the RSS feed from Google Cloud Storage
+2. Extracts all episode GUIDs from the RSS feed
+3. Updates Firestore podcast_jobs collection to set submitted_to_rss: true
+   for all episodes that appear in the RSS feed
+
+Usage:
+    python3 sync_rss_status.py              # Run sync
+    python3 sync_rss_status.py --dry-run    # Preview changes without updating
+
+Requirements:
+    - GCP authentication (via gcloud auth application-default login or service account)
+    - Environment variables:
+      - GOOGLE_CLOUD_PROJECT (default: regal-scholar-453620-r7)
+      - GCP_AUDIO_BUCKET (default: regal-scholar-453620-r7-podcast-storage)
+    - Python packages: google-cloud-firestore, google-cloud-storage
+
+The script will:
+    - Fetch RSS feed from GCS public URL
+    - Parse all episode GUIDs from RSS items
+    - Update Firestore documents where document ID matches RSS GUID
+    - Report statistics on what was updated
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+from typing import Set, List
+from datetime import datetime
+import urllib.request
+import urllib.error
+
+# Google Cloud imports
+try:
+    from google.cloud import firestore
+    from google.cloud import storage
+except ImportError as e:
+    print(f"❌ Error importing Google Cloud libraries: {e}")
+    print("Install with: pip install google-cloud-firestore google-cloud-storage")
+    sys.exit(1)
+
+# Configuration
+GCP_PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT", "regal-scholar-453620-r7")
+GCS_BUCKET = os.getenv("GCP_AUDIO_BUCKET", "regal-scholar-453620-r7-podcast-storage")
+RSS_FEED_PATH = "feeds/copernicus-mvp-rss-feed.xml"
+FIRESTORE_DATABASE = "copernicusai"
+
+# RSS feed URL (public)
+RSS_FEED_URL = f"https://storage.googleapis.com/{GCS_BUCKET}/{RSS_FEED_PATH}"
+
+
+def fetch_rss_feed() -> str:
+    """Fetch RSS feed from GCS (using public URL)"""
+    print(f"📡 Fetching RSS feed from: {RSS_FEED_URL}")
+    try:
+        with urllib.request.urlopen(RSS_FEED_URL, timeout=30) as response:
+            content = response.read().decode('utf-8')
+            print(f"✅ Successfully fetched RSS feed ({len(content)} bytes)")
+            return content
+    except urllib.error.URLError as e:
+        print(f"❌ Error fetching RSS feed: {e}")
+        # Try alternative: read directly from GCS
+        print("🔄 Attempting to read directly from GCS...")
+        try:
+            storage_client = storage.Client(project=GCP_PROJECT_ID)
+            bucket = storage_client.bucket(GCS_BUCKET)
+            blob = bucket.blob(RSS_FEED_PATH)
+            if not blob.exists():
+                raise FileNotFoundError(f"RSS feed not found at gs://{GCS_BUCKET}/{RSS_FEED_PATH}")
+            content = blob.download_as_text()
+            print(f"✅ Successfully read RSS feed from GCS ({len(content)} bytes)")
+            return content
+        except Exception as gcs_error:
+            print(f"❌ Error reading from GCS: {gcs_error}")
+            raise
+
+
+def extract_guids_from_rss(rss_content: str) -> Set[str]:
+    """Extract all GUIDs from RSS feed"""
+    print("🔍 Parsing RSS feed to extract episode GUIDs...")
+    guids = set()
+    
+    try:
+        # Parse XML
+        root = ET.fromstring(rss_content)
+        
+        # Find all <item> elements
+        items = root.findall(".//item")
+        print(f"📋 Found {len(items)} items in RSS feed")
+        
+        for item in items:
+            guid_elem = item.find("guid")
+            if guid_elem is not None:
+                guid_text = guid_elem.text
+                if guid_text:
+                    guids.add(guid_text.strip())
+                    print(f"  ✓ Found GUID: {guid_text.strip()}")
+        
+        print(f"✅ Extracted {len(guids)} unique GUIDs from RSS feed")
+        return guids
+        
+    except ET.ParseError as e:
+        print(f"❌ Error parsing RSS XML: {e}")
+        raise
+    except Exception as e:
+        print(f"❌ Error extracting GUIDs: {e}")
+        raise
+
+
+def sync_firestore_with_rss(rss_guids: Set[str], dry_run: bool = False) -> dict:
+    """Update Firestore to match RSS feed status"""
+    print(f"\n🔄 {'[DRY RUN] ' if dry_run else ''}Syncing Firestore with RSS feed...")
+    
+    try:
+        # Initialize Firestore client
+        print(f"🔌 Connecting to Firestore (project: {GCP_PROJECT_ID}, database: {FIRESTORE_DATABASE})...")
+        db = firestore.Client(project=GCP_PROJECT_ID, database=FIRESTORE_DATABASE)
+        print("✅ Firestore client initialized")
+        
+        # Get all podcast_jobs documents
+        print("📚 Fetching all podcast_jobs from Firestore...")
+        podcast_jobs_ref = db.collection('podcast_jobs')
+        all_podcasts = list(podcast_jobs_ref.stream())
+        print(f"📊 Found {len(all_podcasts)} total podcast jobs in Firestore")
+        
+        # Track statistics
+        stats = {
+            'total_in_firestore': len(all_podcasts),
+            'total_in_rss': len(rss_guids),
+            'matched_and_updated': 0,
+            'matched_already_true': 0,
+            'not_in_rss_but_marked_true': 0,
+            'errors': []
+        }
+        
+        # Update documents that are in RSS feed
+        print(f"\n📝 Updating documents that appear in RSS feed ({len(rss_guids)} episodes)...")
+        for podcast_doc in all_podcasts:
+            doc_id = podcast_doc.id
+            doc_data = podcast_doc.to_dict()
+            current_status = doc_data.get('submitted_to_rss', False)
+            
+            if doc_id in rss_guids:
+                # This episode is in RSS feed
+                if current_status is True:
+                    stats['matched_already_true'] += 1
+                    print(f"  ✓ {doc_id}: Already marked as submitted_to_rss=true")
+                else:
+                    stats['matched_and_updated'] += 1
+                    if not dry_run:
+                        try:
+                            podcast_doc.reference.update({
+                                'submitted_to_rss': True,
+                                'rss_synced_at': datetime.utcnow().isoformat()
+                            })
+                            print(f"  ✅ {doc_id}: Updated submitted_to_rss=true")
+                        except Exception as e:
+                            error_msg = f"Error updating {doc_id}: {e}"
+                            stats['errors'].append(error_msg)
+                            print(f"  ❌ {error_msg}")
+                    else:
+                        print(f"  [DRY RUN] Would update {doc_id}: submitted_to_rss=false -> true")
+            else:
+                # This episode is NOT in RSS feed
+                if current_status is True:
+                    stats['not_in_rss_but_marked_true'] += 1
+                    print(f"  ⚠️  {doc_id}: Marked as submitted_to_rss=true but NOT in RSS feed")
+                    # Optionally set to false - uncomment if desired
+                    # if not dry_run:
+                    #     podcast_doc.reference.update({'submitted_to_rss': False})
+        
+        # Check for RSS GUIDs that don't exist in Firestore
+        print(f"\n🔍 Checking for RSS GUIDs not found in Firestore...")
+        firestore_doc_ids = {doc.id for doc in all_podcasts}
+        missing_in_firestore = rss_guids - firestore_doc_ids
+        if missing_in_firestore:
+            print(f"  ⚠️  Found {len(missing_in_firestore)} GUIDs in RSS feed that don't exist in Firestore:")
+            for guid in sorted(missing_in_firestore):
+                print(f"    - {guid}")
+        else:
+            print(f"  ✅ All RSS GUIDs found in Firestore")
+        
+        return stats
+        
+    except Exception as e:
+        print(f"❌ Error syncing Firestore: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
+
+
+def main():
+    """Main execution function"""
+    print("=" * 70)
+    print("🔄 RSS Feed to Firestore Sync Script")
+    print("=" * 70)
+    print(f"Project: {GCP_PROJECT_ID}")
+    print(f"Database: {FIRESTORE_DATABASE}")
+    print(f"RSS Feed: {RSS_FEED_URL}")
+    print("=" * 70)
+    print()
+    
+    # Check for dry-run flag
+    dry_run = '--dry-run' in sys.argv or '-n' in sys.argv
+    
+    if dry_run:
+        print("⚠️  DRY RUN MODE - No changes will be made to Firestore\n")
+    
+    try:
+        # Step 1: Fetch RSS feed
+        rss_content = fetch_rss_feed()
+        
+        # Step 2: Extract GUIDs
+        rss_guids = extract_guids_from_rss(rss_content)
+        
+        if not rss_guids:
+            print("⚠️  No GUIDs found in RSS feed. Exiting.")
+            return
+        
+        # Step 3: Sync Firestore
+        stats = sync_firestore_with_rss(rss_guids, dry_run=dry_run)
+        
+        # Step 4: Print summary
+        print("\n" + "=" * 70)
+        print("📊 SYNC SUMMARY")
+        print("=" * 70)
+        print(f"Total episodes in RSS feed: {stats['total_in_rss']}")
+        print(f"Total podcast jobs in Firestore: {stats['total_in_firestore']}")
+        print(f"Episodes updated to submitted_to_rss=true: {stats['matched_and_updated']}")
+        print(f"Episodes already marked as submitted_to_rss=true: {stats['matched_already_true']}")
+        print(f"Episodes in Firestore but NOT in RSS (marked true): {stats['not_in_rss_but_marked_true']}")
+        if stats['errors']:
+            print(f"\n❌ Errors encountered: {len(stats['errors'])}")
+            for error in stats['errors']:
+                print(f"  - {error}")
+        print("=" * 70)
+        
+        if dry_run:
+            print("\n⚠️  This was a DRY RUN. Run without --dry-run to apply changes.")
+        else:
+            print("\n✅ Sync completed successfully!")
+        
+    except KeyboardInterrupt:
+        print("\n\n⚠️  Interrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Fatal error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_sync_endpoint.html
+++ b/test_sync_endpoint.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RSS Sync Endpoint Tester</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        button {
+            background: #2563eb;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+            margin: 10px 5px;
+        }
+        button:hover {
+            background: #1d4ed8;
+        }
+        button:disabled {
+            background: #9ca3af;
+            cursor: not-allowed;
+        }
+        #result {
+            margin-top: 20px;
+            padding: 15px;
+            border-radius: 6px;
+            white-space: pre-wrap;
+            font-family: monospace;
+            font-size: 14px;
+        }
+        .success {
+            background: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+        .error {
+            background: #fee2e2;
+            color: #991b1b;
+            border: 1px solid #fca5a5;
+        }
+        .loading {
+            background: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🔄 RSS Status Sync Tester</h1>
+        <p>Click the button below to trigger the RSS sync endpoint.</p>
+        
+        <button id="syncBtn" onclick="runSync()">Run RSS Sync</button>
+        <button onclick="checkEndpoint()">Test Endpoint (GET)</button>
+        
+        <div id="result"></div>
+    </div>
+
+    <script>
+        const API_URL = 'https://copernicus-podcast-api-204731194849.us-central1.run.app/api/admin/episodes/sync-rss-status';
+        
+        function showResult(message, type = 'loading') {
+            const resultDiv = document.getElementById('result');
+            resultDiv.className = type;
+            resultDiv.textContent = message;
+        }
+        
+        async function runSync() {
+            const btn = document.getElementById('syncBtn');
+            btn.disabled = true;
+            showResult('🔄 Running sync... Please wait (this may take 30-60 seconds)...', 'loading');
+            
+            try {
+                const response = await fetch(API_URL, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    }
+                });
+                
+                const data = await response.json();
+                
+                if (response.ok) {
+                    showResult(
+                        '✅ SUCCESS!\n\n' +
+                        JSON.stringify(data, null, 2) +
+                        '\n\nSummary:\n' +
+                        `- Episodes in RSS: ${data.stats?.total_in_rss || 'N/A'}\n` +
+                        `- Episodes in Firestore: ${data.stats?.total_in_firestore || 'N/A'}\n` +
+                        `- Updated: ${data.stats?.updated || 0}\n` +
+                        `- Already marked: ${data.stats?.already_marked || 0}`,
+                        'success'
+                    );
+                } else {
+                    showResult(
+                        '❌ ERROR\n\n' +
+                        `Status: ${response.status} ${response.statusText}\n` +
+                        JSON.stringify(data, null, 2),
+                        'error'
+                    );
+                }
+            } catch (error) {
+                showResult(
+                    '❌ ERROR\n\n' +
+                    'Failed to connect to endpoint:\n' +
+                    error.message + '\n\n' +
+                    'Possible issues:\n' +
+                    '1. Endpoint not deployed yet\n' +
+                    '2. CORS blocking the request\n' +
+                    '3. Network error\n\n' +
+                    'Try using curl or check if the endpoint exists.',
+                    'error'
+                );
+            } finally {
+                btn.disabled = false;
+            }
+        }
+        
+        async function checkEndpoint() {
+            showResult('🔄 Checking if endpoint exists...', 'loading');
+            
+            try {
+                // Try OPTIONS first (CORS preflight)
+                const optionsResponse = await fetch(API_URL, {
+                    method: 'OPTIONS'
+                });
+                
+                showResult(
+                    `Endpoint check:\n` +
+                    `- URL: ${API_URL}\n` +
+                    `- OPTIONS status: ${optionsResponse.status}\n` +
+                    `- CORS headers: ${optionsResponse.headers.get('Access-Control-Allow-Methods') || 'Not set'}\n\n` +
+                    `Note: This endpoint requires POST method. Use the "Run RSS Sync" button above.`,
+                    optionsResponse.ok ? 'success' : 'error'
+                );
+            } catch (error) {
+                showResult(
+                    '❌ Cannot reach endpoint\n\n' +
+                    error.message + '\n\n' +
+                    'The endpoint may not be deployed yet, or there may be a network issue.',
+                    'error'
+                );
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add a script and an admin endpoint to sync Firestore episode `submitted_to_rss` status with the RSS feed.

The original `sync_rss_status.py` script was unavailable, preventing debugging of its hanging issue. This PR recreates the script and adds a corresponding admin API endpoint to resolve the discrepancy where Firestore showed only 2 episodes as submitted while the RSS feed had 39.

---
<a href="https://cursor.com/background-agent?bcId=bc-614a4953-fa6c-4520-bdb8-d8e080c5fc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-614a4953-fa6c-4520-bdb8-d8e080c5fc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

